### PR TITLE
remove duplicate pack declaration

### DIFF
--- a/module.json
+++ b/module.json
@@ -77,15 +77,6 @@
       "private": false
     },
     {
-      "label": "Inkfinder - Alchemist Options",
-      "type": "Item",
-      "name": "inkfinder1-alchemist-options",
-      "path": "./packs/inkfinder1-alchemist-options.db",
-      "system": "pf2e",
-      "package": "inkfinder1",
-      "private": false
-    },
-    {
       "label": "Inkfinder - Archetypes",
       "type": "Item",
       "name": "inkfinder1-archetypes",


### PR DESCRIPTION
Alchemist Options is defined twice in the packs within module.json. This takes one of them out so the module will install.